### PR TITLE
feat: :sparkles: Add color palette

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,8 +22,39 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    - always_use_package_imports
+    - avoid_empty_else
+    - avoid_print
+    - avoid_relative_lib_imports
+    - avoid_shadowing_type_parameters
+    - avoid_types_as_parameter_names
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
+    - curly_braces_in_flow_control_structures
+    - depend_on_referenced_packages
+    - empty_catches
+    - empty_statements
+    - file_names
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - no_duplicate_case_values
+    - non_constant_identifier_names
+    - null_check_on_nullable_type_parameter
+    - only_throw_errors
+    - package_prefixed_library_names
+    - prefer_generic_function_type_aliases
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    - prefer_single_quotes
+    - prefer_typing_uninitialized_variables
+    - provide_deprecation_message
+    - unnecessary_overrides
+    - unrelated_type_equality_checks
+    - valid_regexps
+    - void_checks
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/classes/hexcolor.dart
+++ b/lib/classes/hexcolor.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class HexColor {
+  String color;
+
+  HexColor({required this.color});
+
+  toColor() {
+    String hexString = color;
+    final buffer = StringBuffer();
+    if (color.length == 6 || hexString.length == 7) buffer.write('ff');
+    buffer.write(hexString.replaceFirst('#', ''));
+    return Color(int.parse(buffer.toString(), radix: 16));
+  }
+}

--- a/lib/classes/material_color_generator.dart
+++ b/lib/classes/material_color_generator.dart
@@ -1,0 +1,41 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+
+class MaterialColorGenerator {
+  Color color;
+
+  MaterialColorGenerator({required this.color});
+
+  MaterialColor generate() {
+    return MaterialColor(color.value, {
+      50: tintColor(color, 0.9),
+      100: tintColor(color, 0.8),
+      200: tintColor(color, 0.6),
+      300: tintColor(color, 0.4),
+      400: tintColor(color, 0.2),
+      500: color,
+      600: shadeColor(color, 0.1),
+      700: shadeColor(color, 0.2),
+      800: shadeColor(color, 0.3),
+      900: shadeColor(color, 0.4),
+    });
+  }
+
+  static int tintValue(int value, double factor) =>
+      max(0, min((value + ((255 - value) * factor)).round(), 255));
+
+  static Color tintColor(Color color, double factor) => Color.fromRGBO(
+      tintValue(color.red, factor),
+      tintValue(color.green, factor),
+      tintValue(color.blue, factor),
+      1);
+
+  static int shadeValue(int value, double factor) =>
+      max(0, min(value - (value * factor).round(), 255));
+
+  static Color shadeColor(Color color, double factor) => Color.fromRGBO(
+      shadeValue(color.red, factor),
+      shadeValue(color.green, factor),
+      shadeValue(color.blue, factor),
+      1);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pocketdex/themes/palette.dart';
 
 void main() {
   runApp(const MyApp());
@@ -11,7 +12,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'PocketDex',
       theme: ThemeData(
         // This is the theme of your application.
         //
@@ -22,9 +23,14 @@ class MyApp extends StatelessWidget {
         // or simply save your changes to "hot reload" in a Flutter IDE).
         // Notice that the counter didn't reset back to zero; the application
         // is not restarted.
-        primarySwatch: Colors.blue,
+        primarySwatch: palette['common']?['bittersweet'],
+        scaffoldBackgroundColor: palette['common']?['anti-flash-white'],
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      darkTheme: ThemeData(
+        primarySwatch: palette['common']?['red-pantone'],
+        scaffoldBackgroundColor: palette['common']?['space-cadet'],
+      ),
+      home: const MyHomePage(title: 'Home'),
     );
   }
 }

--- a/lib/themes/colors.dart
+++ b/lib/themes/colors.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:pocketdex/classes/hexcolor.dart';
+
+const colors = {
+  'common': {
+    'space-cadet': '#2B2D42',
+    'cool-gray': '#8D99AE',
+    'anti-flash-white': '#EDF2F4',
+    'bittersweet': '#FF5A5F',
+    'red-pantone': '#EF233C',
+  },
+};
+
+final convertedColors =
+    Map<String, Map<String, Color>>.from(colors.map((key, value) {
+  return MapEntry(key, Map<String, Color>.from(value.map((k, v) {
+    return MapEntry(k, HexColor(color: v).toColor());
+  })));
+}));

--- a/lib/themes/palette.dart
+++ b/lib/themes/palette.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:pocketdex/classes/material_color_generator.dart';
+import 'package:pocketdex/themes/colors.dart';
+
+final palette = Map<String, Map<String, MaterialColor>>.from(
+    convertedColors.map((key, value) {
+  return MapEntry(key, Map<String, MaterialColor>.from(value.map((k, v) {
+    return MapEntry(k, MaterialColorGenerator(color: v).generate());
+  })));
+}));


### PR DESCRIPTION
# Description

> Describe the changes made by this pull request.

Added:
- HexColor (class)
- MaterialColorGenerator (class)
- colors (theme - map)
- covertedColors (theme - map)
- palette (theme - map)

Modified:
- Application name
- light and dark theme default colors

## Related issues

> List related issues (if any) and/or @mentions of the person or team responsible for reviewing proposed changes (left blank if not applicable).
> List by using - [ ] and the issue number, e.g. `- [ ] #1` or `- [x] #1` if the issue is closed/solved.

- [x] #2 

## Testing

> Help me how can I test or look at the changes (left blank if not applicable).

## Screenshots

> Include screenshots of the results or screenshots that help to see changes (left blank if not applicable).

| Windows |
| :---: |
| ![image](https://user-images.githubusercontent.com/45635827/235277109-b87e771b-7680-40b0-aea2-8778d9521385.png) |

## Notes

> Some additional notes if necessary (left blank if not applicable).

- More colors may be added in the future, these are only the principal colors