### PR TITLE
refactor: :recycle: Remove pages instances from `AppPage` enum

### DIFF
--- a/lib/constants/pages.dart
+++ b/lib/constants/pages.dart
@@ -1,21 +1,11 @@
-import 'package:flutter/material.dart';
-
-import 'package:pocketdex/pages/home.dart';
-import 'package:pocketdex/pages/settings.dart';
-
-enum AppPage { home, settings }
+enum AppPage { home, pokemon, settings }
 
 extension AppPageEx on AppPage {
-  static const Map<String, Widget> _pages = {
-    'home': HomePage(),
-    'settings': SettingsPage()
-  };
+  String get id {
+    return name;
+  }
 
   String get pageName {
     return '${name[0].toUpperCase()}${name.substring(1).toLowerCase()}';
-  }
-
-  Widget get page {
-    return _pages[name]!;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pocketdex/pages/home.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -34,9 +35,6 @@ class App extends StatefulWidget {
 
   @override
   State<App> createState() => _AppState();
-
-  // static MyAppState? of(BuildContext context) =>
-  //     context.findAncestorStateOfType<MyAppState>();
 }
 
 class _AppState extends State<App> {
@@ -44,7 +42,7 @@ class _AppState extends State<App> {
   Widget build(BuildContext context) {
     return MaterialApp(
       darkTheme: theme['dark']!(context: context),
-      home: Provider.of<SelectPageNotifier>(context).selectedPage.page,
+      home: const HomePage(),
       theme: theme['light']!(context: context),
       themeMode: Provider.of<ThemeModeNotifier>(context).themeMode,
       title: 'PocketDex',

--- a/lib/widgets/drawers/default.dart
+++ b/lib/widgets/drawers/default.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:pocketdex/pages/home.dart';
+import 'package:pocketdex/pages/settings.dart';
 import 'package:provider/provider.dart';
 
 import 'package:pocketdex/classes/create_animated_route.dart';
@@ -56,7 +58,7 @@ class _DefaultDrawerState extends State<DefaultDrawer> {
                     Navigator.pushReplacement(
                       context,
                       CreateAnimatedRoute(
-                        page: AppPage.home.page,
+                        page: const HomePage(),
                       ).slideHorizontally(),
                     );
                   },
@@ -74,7 +76,7 @@ class _DefaultDrawerState extends State<DefaultDrawer> {
                     Navigator.pushReplacement(
                       context,
                       CreateAnimatedRoute(
-                        page: AppPage.settings.page,
+                        page: const SettingsPage(),
                       ).slideHorizontally(),
                     );
                   },


### PR DESCRIPTION
# Description

> Describe the changes made by this pull request.

This PR removes pages instances from the `AppPage` enum.

modify:
- `AppPage` enum
- `AppPageEx` enum extension
- `MaterialApp` default home instance
- `DefaultDrawer` pages instance

remove:
- comments on main

## Related issues

> List related issues (if any) and/or @mentions of the person or team responsible for reviewing proposed changes (left blank if not applicable).
> List by using - [ ] and the issue number, e.g. `- [ ] #1` or `- [x] #1` if the issue is closed/solved.
- [x] #17

## Testing

> Help me how can I test or look at the changes (left blank if not applicable).

## Screenshots

> Include screenshots of the results or screenshots that help to see changes (left blank if not applicable).

## Notes

> Some additional notes if necessary (left blank if not applicable).
