### PR TITLE
refactor: :recycle: Remake `HomePage` and `PokemonCard` using the `pokedex` library

### DIFF
--- a/lib/classes/color_maker.dart
+++ b/lib/classes/color_maker.dart
@@ -2,22 +2,24 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 
 class ColorMaker {
-  static Color _getShadeColor(Color color, double factor) => Color.fromRGBO(
-      _getShadeValue(color.red, factor),
-      _getShadeValue(color.green, factor),
-      _getShadeValue(color.blue, factor),
-      1);
+  static Color _getShadeColor({required Color color, required double factor}) =>
+      Color.fromRGBO(
+          _getShadeValue(value: color.red, factor: factor),
+          _getShadeValue(value: color.green, factor: factor),
+          _getShadeValue(value: color.blue, factor: factor),
+          1);
 
-  static int _getShadeValue(int value, double factor) =>
+  static int _getShadeValue({required int value, required double factor}) =>
       max(0, min(value - (value * factor).round(), 255));
 
-  static Color _getTintColor(Color color, double factor) => Color.fromRGBO(
-      _getTintValue(color.red, factor),
-      _getTintValue(color.green, factor),
-      _getTintValue(color.blue, factor),
-      1);
+  static Color _getTintColor({required Color color, required double factor}) =>
+      Color.fromRGBO(
+          _getTintValue(value: color.red, factor: factor),
+          _getTintValue(value: color.green, factor: factor),
+          _getTintValue(value: color.blue, factor: factor),
+          1);
 
-  static int _getTintValue(int value, double factor) =>
+  static int _getTintValue({required int value, required double factor}) =>
       max(0, min((value + ((255 - value) * factor)).round(), 255));
 
   static MaterialColor? combineMaterialColors(
@@ -40,18 +42,19 @@ class ColorMaker {
     return toMaterialColor(color: color);
   }
 
-  static MaterialColor toMaterialColor({required color}) {
+  static MaterialColor toMaterialColor({required Color? color}) {
+    color ??= Colors.transparent;
     return MaterialColor(color.value, {
-      50: _getTintColor(color, 0.9),
-      100: _getTintColor(color, 0.8),
-      200: _getTintColor(color, 0.6),
-      300: _getTintColor(color, 0.4),
-      400: _getTintColor(color, 0.2),
+      50: _getTintColor(color: color, factor: 0.9),
+      100: _getTintColor(color: color, factor: 0.8),
+      200: _getTintColor(color: color, factor: 0.6),
+      300: _getTintColor(color: color, factor: 0.4),
+      400: _getTintColor(color: color, factor: 0.2),
       500: color,
-      600: _getShadeColor(color, 0.1),
-      700: _getShadeColor(color, 0.2),
-      800: _getShadeColor(color, 0.3),
-      900: _getShadeColor(color, 0.4),
+      600: _getShadeColor(color: color, factor: 0.1),
+      700: _getShadeColor(color: color, factor: 0.2),
+      800: _getShadeColor(color: color, factor: 0.3),
+      900: _getShadeColor(color: color, factor: 0.4),
     });
   }
 }

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:pokeapi/model/pokemon/pokemon.dart';
-import 'package:pokeapi/pokeapi.dart';
+import 'package:pokedex/pokedex.dart';
 
 import 'package:pocketdex/constants/pages.dart';
 import 'package:pocketdex/widgets/cards/pokemon.dart';
@@ -35,9 +34,13 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _fetchPokemons() async {
     try {
-      _pokemons.addAll(
-          (await PokeAPI.getObjectList<Pokemon>(_pokemons.length + 1, 10))
-              .whereType<Pokemon>());
+      _pokemons.addAll((await Future.wait((await Pokedex()
+                  .pokemon
+                  .getPage(offset: _pokemons.length, limit: 10))
+              .results
+              .map((partialPokemon) =>
+                  Pokedex().pokemon.get(name: partialPokemon.name))))
+          .whereType<Pokemon>());
     } catch (e) {
       setState(() {
         isLimit = true;
@@ -76,7 +79,10 @@ class _HomePageState extends State<HomePage> {
               itemCount: _pokemons.length + 1,
               itemBuilder: (context, index) {
                 if (index < _pokemons.length) {
-                  return PokemonCard(pokemon: _pokemons[index]);
+                  return InkWell(
+                    child: PokemonCard(pokemon: _pokemons[index]),
+                    onTap: () {},
+                  );
                 } else if (!isLimit) {
                   return const Card(
                     child: Padding(

--- a/lib/widgets/cards/pokemon.dart
+++ b/lib/widgets/cards/pokemon.dart
@@ -1,6 +1,6 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
-import 'package:pokeapi/model/pokemon/pokemon.dart';
+import 'package:pokedex/pokedex.dart';
 
 import 'package:pocketdex/classes/color_maker.dart';
 import 'package:pocketdex/themes/palette.dart';
@@ -22,9 +22,16 @@ class PokemonCard extends StatelessWidget {
 
   MaterialColor combineTypesColors() {
     return ColorMaker.combineMultipleMaterialColor(
-        materialColors: pokemon.types!
-            .map((type) => palette['types']?[type.type!.name])
+        materialColors: pokemon.types
+            .map((type) => palette['types']?[type.type.name])
             .toList());
+  }
+
+  MaterialColor combineCardAndTypesColors(BuildContext context) {
+    return ColorMaker.combineMultipleMaterialColor(materialColors: [
+      ColorMaker.toMaterialColor(color: Theme.of(context).cardTheme.color),
+      combineTypesColors()
+    ], dominance: 0.2);
   }
 
   Color? getTextColor(Color? backgroundColor) {
@@ -41,6 +48,7 @@ class PokemonCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
+      color: combineCardAndTypesColors(context),
       child: Row(
         children: [
           Expanded(
@@ -55,9 +63,7 @@ class PokemonCard extends StatelessWidget {
                         flex: 1,
                         child: Container(
                           decoration: BoxDecoration(
-                            color: pokemon.types != null
-                                ? (combineTypesColors())[colorsShade['id']!]
-                                : null,
+                            color: (combineTypesColors())[colorsShade['id']!],
                             borderRadius: const BorderRadius.only(
                               topLeft: Radius.circular(5),
                               bottomLeft: Radius.circular(5),
@@ -65,13 +71,10 @@ class PokemonCard extends StatelessWidget {
                           ),
                           child: Center(
                             child: Text(
-                              pokemon.id!.toString(),
+                              pokemon.id.toString(),
                               style: TextStyle(
                                 color: getTextColor(
-                                  pokemon.types != null
-                                      ? (combineTypesColors())[
-                                          colorsShade['id']!]
-                                      : null,
+                                  (combineTypesColors())[colorsShade['id']!],
                                 ),
                                 fontWeight: FontWeight.bold,
                               ),
@@ -83,9 +86,7 @@ class PokemonCard extends StatelessWidget {
                         flex: 3,
                         child: Container(
                           decoration: BoxDecoration(
-                            color: pokemon.types != null
-                                ? (combineTypesColors())[colorsShade['name']!]
-                                : null,
+                            color: (combineTypesColors())[colorsShade['name']!],
                             borderRadius: const BorderRadius.only(
                               topRight: Radius.circular(5),
                               bottomRight: Radius.circular(5),
@@ -93,13 +94,10 @@ class PokemonCard extends StatelessWidget {
                           ),
                           child: Center(
                             child: Text(
-                              '${pokemon.name?[0].toUpperCase()}${pokemon.name?.substring(1)}',
+                              '${pokemon.name[0].toUpperCase()}${pokemon.name.substring(1)}',
                               style: TextStyle(
                                 color: getTextColor(
-                                  pokemon.types != null
-                                      ? (combineTypesColors())[
-                                          colorsShade['name']!]
-                                      : null,
+                                  (combineTypesColors())[colorsShade['name']!],
                                 ),
                               ),
                             ),
@@ -112,48 +110,37 @@ class PokemonCard extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.all(5),
                   child: Row(
-                    children: pokemon.types != null
-                        ? pokemon.types!
-                            .map(
-                              (type) => Expanded(
-                                child: Padding(
-                                  padding: EdgeInsets.only(
-                                      left: type == pokemon.types!.first
-                                          ? 0
-                                          : 2.5,
-                                      right: type == pokemon.types!.last
-                                          ? 0
-                                          : 2.5),
-                                  child: type.type?.name != null
-                                      ? Container(
-                                          decoration: BoxDecoration(
-                                            color: (palette['types']?[type.type!
-                                                .name])?[colorsShade['type']!],
-                                            borderRadius:
-                                                const BorderRadius.all(
-                                                    Radius.circular(5)),
-                                          ),
-                                          child: Center(
-                                            child: Text(
-                                              type.type!.name![0]
-                                                      .toUpperCase() +
-                                                  type.type!.name!.substring(1),
-                                              style: TextStyle(
-                                                color: getTextColor(
-                                                  (palette['types']
-                                                          ?[type.type!.name])?[
-                                                      colorsShade['type']!],
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                        )
-                                      : null,
+                    children: pokemon.types
+                        .map(
+                          (type) => Expanded(
+                            child: Padding(
+                              padding: EdgeInsets.only(
+                                  left: type == pokemon.types.first ? 0 : 2.5,
+                                  right: type == pokemon.types.last ? 0 : 2.5),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: (palette['types']
+                                      ?[type.type.name])?[colorsShade['type']!],
+                                  borderRadius: const BorderRadius.all(
+                                      Radius.circular(5)),
+                                ),
+                                child: Center(
+                                  child: Text(
+                                    type.type.name[0].toUpperCase() +
+                                        type.type.name.substring(1),
+                                    style: TextStyle(
+                                      color: getTextColor(
+                                        (palette['types']?[type.type.name])?[
+                                            colorsShade['type']!],
+                                      ),
+                                    ),
+                                  ),
                                 ),
                               ),
-                            )
-                            .toList()
-                        : [],
+                            ),
+                          ),
+                        )
+                        .toList(),
                   ),
                 ),
               ],
@@ -182,38 +169,34 @@ class PokemonCard extends StatelessWidget {
                             child: Icon(
                               Icons.catching_pokemon,
                               size: iconSize,
-                              color: pokemon.types != null
-                                  ? (combineTypesColors())[
-                                      colorsShade['sprite']!]
-                                  : null,
+                              color: (combineTypesColors())[
+                                  colorsShade['sprite']!],
                             ),
                           );
                         },
                       ),
                       Center(
-                        child: pokemon.sprites != null
-                            ? CarouselSlider(
-                                options: CarouselOptions(
-                                  aspectRatio: 1,
-                                  viewportFraction: 1,
-                                  enlargeCenterPage: true,
-                                  enableInfiniteScroll: false,
-                                  enlargeFactor: 2,
+                        child: CarouselSlider(
+                          options: CarouselOptions(
+                            aspectRatio: 1,
+                            viewportFraction: 1,
+                            enlargeCenterPage: true,
+                            enableInfiniteScroll: false,
+                            enlargeFactor: 2,
+                          ),
+                          items: [
+                            pokemon.sprites.frontDefault,
+                            pokemon.sprites.backDefault
+                          ]
+                              .whereType<String>()
+                              .map(
+                                (sprite) => Image.network(
+                                  sprite,
+                                  fit: BoxFit.contain,
                                 ),
-                                items: [
-                                  pokemon.sprites!.frontDefault,
-                                  pokemon.sprites!.backDefault
-                                ]
-                                    .whereType<String>()
-                                    .map(
-                                      (sprite) => Image.network(
-                                        sprite,
-                                        fit: BoxFit.contain,
-                                      ),
-                                    )
-                                    .toList(),
                               )
-                            : null,
+                              .toList(),
+                        ),
                       )
                     ],
                   ),


### PR DESCRIPTION
# Description

> Describe the changes made by this pull request.

This PR remakes `HomePage` and `PokemonCard` in order to use the `pokedex` library, and also modifies the card by combining types and card background color.

modify:
- `ColorMaker` now uses argument names in its methods
- `HomePage` is now using `pokedex` library
- `PokemonCard` is now using `pokedex` library and combining card and types colors

## Related issues

> List related issues (if any) and/or @mentions of the person or team responsible for reviewing proposed changes (left blank if not applicable).
> List by using - [ ] and the issue number, e.g. `- [ ] #1` or `- [x] #1` if the issue is closed/solved.

- [x] #21 

## Testing

> Help me how can I test or look at the changes (left blank if not applicable).

## Screenshots

> Include screenshots of the results or screenshots that help to see changes (left blank if not applicable).

<table>
  <thead>
    <tr>
      <th colspan="2" style="text-align: center;">Theme</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th style="text-align: center;">Dark</th>
      <th style="text-align: center;">Light</th>
    </tr>
    <tr>
      <td><img src="https://github.com/BlessInSoftware/PocketDex/assets/45635827/772c1bbc-684f-400c-8815-2bc8b8882b39" alt="Dark card"></td>
      <td><img src="https://github.com/BlessInSoftware/PocketDex/assets/45635827/31c44e31-3b41-45a0-8761-6915655eeb32" alt="Light card"></td>
    </tr>
  </tbody>
</table>

## Notes

> Some additional notes if necessary (left blank if not applicable).

- Colors card colors combination of `PokemonCard` may be pass as props in the future because maybe other components will depend on it.
