### PR TITLE
feat: :sparkles: Pokémon searcher

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:pokedex/pokedex.dart';
 
+import 'package:pocketdex/classes/create_animated_route.dart';
 import 'package:pocketdex/constants/pages.dart';
-import 'package:pocketdex/widgets/cards/pokemon.dart';
+import 'package:pocketdex/pages/pokemon.dart';
 import 'package:pocketdex/widgets/buttons/floating.dart';
+import 'package:pocketdex/widgets/cards/pokemon.dart';
 import 'package:pocketdex/widgets/drawers/default.dart';
+import 'package:pocketdex/widgets/searchers/pokemon.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -71,6 +74,13 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        actions: [
+          IconButton(
+              onPressed: () {
+                showSearch(context: context, delegate: PokemonSearchDelegate());
+              },
+              icon: const Icon(Icons.search))
+        ],
         title: Text(AppPage.home.pageName),
       ),
       body: _pokemons.isNotEmpty
@@ -81,7 +91,15 @@ class _HomePageState extends State<HomePage> {
                 if (index < _pokemons.length) {
                   return InkWell(
                     child: PokemonCard(pokemon: _pokemons[index]),
-                    onTap: () {},
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        CreateAnimatedRoute(
+                          page: PokemonPage(
+                              partialPokemon: _pokemons[index].name),
+                        ).slideVertically(),
+                      );
+                    },
                   );
                 } else if (!isLimit) {
                   return const Card(

--- a/lib/pages/pokemon.dart
+++ b/lib/pages/pokemon.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:pokedex/pokedex.dart';
+
+import 'package:pocketdex/constants/pages.dart';
+import 'package:pocketdex/widgets/buttons/floating.dart';
+import 'package:pocketdex/widgets/cards/pokemon.dart';
+import 'package:pocketdex/widgets/searchers/pokemon.dart';
+
+class PokemonPage extends StatefulWidget {
+  final String _partialPokemon;
+
+  const PokemonPage({super.key, required String partialPokemon})
+      : _partialPokemon = partialPokemon;
+
+  @override
+  State<PokemonPage> createState() => _PokemonPageState();
+}
+
+class _PokemonPageState extends State<PokemonPage> {
+  Pokemon? _pokemon;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchPokemon();
+  }
+
+  void _fetchPokemon() async {
+    final pokemon = await Pokedex().pokemon.get(name: widget._partialPokemon);
+    setState(() {
+      _pokemon = pokemon;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        actions: [
+          IconButton(
+              onPressed: () {
+                showSearch(
+                    context: context,
+                    delegate: PokemonSearchDelegate(pushReplacement: true));
+              },
+              icon: const Icon(Icons.search))
+        ],
+        title: Text(AppPage.pokemon.pageName),
+      ),
+      body: _pokemon != null
+          ? Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[PokemonCard(pokemon: _pokemon!)],
+            )
+          : const Center(child: CircularProgressIndicator()),
+      floatingActionButton: const FloatingButton(),
+    );
+  }
+}

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 
+import 'package:pocketdex/classes/theme_mode_notifier.dart';
 import 'package:pocketdex/themes/palette.dart';
 
 final Map<String, ThemeData Function({required BuildContext context})> theme = {
@@ -71,3 +74,35 @@ final Map<String, ThemeData Function({required BuildContext context})> theme = {
     );
   }
 };
+
+ThemeData searchDelegateTheme(BuildContext context) {
+  final ThemeData theme = Theme.of(context);
+  final ThemeMode themeMode =
+      Provider.of<ThemeModeNotifier>(context).themeMode != ThemeMode.system
+          ? Provider.of<ThemeModeNotifier>(context).themeMode
+          : MediaQuery.of(context).platformBrightness == Brightness.dark
+              ? ThemeMode.dark
+              : ThemeMode.light;
+  return theme.copyWith(
+    appBarTheme: AppBarTheme(
+      systemOverlayStyle: themeMode == ThemeMode.dark
+          ? SystemUiOverlayStyle.light
+          : SystemUiOverlayStyle.dark,
+      backgroundColor: themeMode == ThemeMode.dark
+          ? (palette['common']?['space-cadet']?[900])
+          : (palette['common']?['anti-flash-white']?[700]),
+      iconTheme: theme.primaryIconTheme.copyWith(
+        color: themeMode == ThemeMode.dark
+            ? (palette['common']?['anti-flash-white'])
+            : (palette['common']?['space-cadet']),
+      ),
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      hintStyle: TextStyle(
+        color: themeMode == ThemeMode.dark
+            ? (palette['common']?['anti-flash-white']?[900])
+            : (palette['common']?['space-cadet']?[400]),
+      ),
+    ),
+  );
+}

--- a/lib/widgets/searchers/pokemon.dart
+++ b/lib/widgets/searchers/pokemon.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:pokedex/pokedex.dart';
+
+import 'package:pocketdex/classes/create_animated_route.dart';
+import 'package:pocketdex/pages/pokemon.dart';
+import 'package:pocketdex/themes/theme.dart';
+
+class PokemonSearchDelegate extends SearchDelegate {
+  final pokemonList = Pokedex().pokemon.getAll();
+  final bool _pushReplacement;
+
+  PokemonSearchDelegate({bool pushReplacement = false})
+      : _pushReplacement = pushReplacement;
+
+  @override
+  String? get searchFieldLabel => 'Search for a Pokémon';
+
+  Widget _searchResults(BuildContext context) {
+    try {
+      return FutureBuilder(
+        future: pokemonList,
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Center(child: Text(snapshot.error.toString()));
+          } else {
+            if (snapshot.connectionState == ConnectionState.done &&
+                snapshot.hasData) {
+              final filteredPokemonsList = (snapshot.data!.results
+                  .where((element) =>
+                      element.name.startsWith(query.toLowerCase()) ||
+                      element.url.contains(query.toLowerCase()))
+                  .toList());
+              if (filteredPokemonsList.isNotEmpty) {
+                return ListView.builder(
+                  itemCount: filteredPokemonsList.length,
+                  itemBuilder: (context, index) {
+                    final pokemon = filteredPokemonsList[index].name;
+                    return InkWell(
+                      onTap: () {
+                        close(context, null);
+                        snapshot.data != null
+                            ? _pushReplacement
+                                ? Navigator.pushReplacement(
+                                    context,
+                                    CreateAnimatedRoute(
+                                      page:
+                                          PokemonPage(partialPokemon: pokemon),
+                                    ).slideVertically(),
+                                  )
+                                : Navigator.push(
+                                    context,
+                                    CreateAnimatedRoute(
+                                      page:
+                                          PokemonPage(partialPokemon: pokemon),
+                                    ).slideVertically(),
+                                  )
+                            : null;
+                      },
+                      child: ListTile(
+                        title: Text(
+                            '${pokemon[0].toUpperCase()}${pokemon.substring(1)}'),
+                      ),
+                    );
+                  },
+                );
+              } else {
+                return const Center(child: Text('Not found'));
+              }
+            } else {
+              return const Center(child: CircularProgressIndicator());
+            }
+          }
+        },
+      );
+    } catch (e) {
+      return Center(child: Text(e.toString()));
+    }
+  }
+
+  @override
+  ThemeData appBarTheme(BuildContext context) => searchDelegateTheme(context);
+
+  @override
+  List<Widget> buildActions(BuildContext context) {
+    return [
+      IconButton(
+          onPressed: () {
+            if (query.isNotEmpty) {
+              query = '';
+            } else {
+              close(context, null);
+            }
+          },
+          icon: const Icon(Icons.clear))
+    ];
+  }
+
+  @override
+  Widget buildLeading(BuildContext context) {
+    return IconButton(
+        onPressed: () {
+          close(context, null);
+        },
+        icon: const Icon(Icons.arrow_back));
+  }
+
+  @override
+  Widget buildResults(BuildContext context) {
+    return _searchResults(context);
+  }
+
+  @override
+  Widget buildSuggestions(BuildContext context) {
+    return _searchResults(context);
+  }
+}


### PR DESCRIPTION
# Description

> Describe the changes made by this pull request.

This PR adds the searcher for pokémons, it's attached into the app bar.

add:
- search button in `HomePage` and `PokemonPage`
- navigation in `HomePage` and `PokemonPage`
- `PokemonPage` (work in progress)
- theme for all search delegates (`searchDelegateTheme`)
- `PokemonSearchDelegate`

## Related issues

> List related issues (if any) and/or @mentions of the person or team responsible for reviewing proposed changes (left blank if not applicable).
> List by using - [ ] and the issue number, e.g. `- [ ] #1` or `- [x] #1` if the issue is closed/solved.

- [x] #23

## Testing

> Help me how can I test or look at the changes (left blank if not applicable).

## Screenshots

> Include screenshots of the results or screenshots that help to see changes (left blank if not applicable).

<table>
  <thead>
    <tr>
      <th colspan="2" style="text-align: center;">Theme</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th style="text-align: center;">Dark</th>
      <th style="text-align: center;">Light</th>
    </tr>
    <tr>
      <td><img src="https://github.com/BlessInSoftware/PocketDex/assets/45635827/a40744db-5c7a-4650-8f3d-a0c59bd06893" alt="Dark home page"></td>
      <td><img src="https://github.com/BlessInSoftware/PocketDex/assets/45635827/ac28a0e7-ef7b-4aaf-9b00-9eeefa4e62b3" alt="Light home page"></td>
    </tr>
        <tr>
      <td><img src="https://github.com/BlessInSoftware/PocketDex/assets/45635827/9ed9b12b-1db0-4176-8e1c-4085f3804c0f" alt="Dark home page"></td>
      <td><img src="https://github.com/BlessInSoftware/PocketDex/assets/45635827/fca043f3-0952-4802-bf76-bcd0b69e78ff" alt="Light home page"></td>
    </tr>
  </tbody>
</table>

## Notes

> Some additional notes if necessary (left blank if not applicable).

- The `PokemonSearchDelegate` may be changed in the future, showing even more results than only pokémons.