### PR TITLE
build: :package: add Android `INTERNET` permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.blessinsoftware.pocketdex">
+   <uses-permission android:name="android.permission.INTERNET" />
    <application
         android:label="PocketDex"
         android:name="${applicationName}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
# Description

> Describe the changes made by this pull request.

This PR fixes the issue of data not being loaded on the Android release build by adding the `INTERNET` permission.

modify:
- `AndroidManifest` and `build` files of `android` folder

## Related issues

- [x] #27

> List related issues (if any) and/or @mentions of the person or team responsible for reviewing proposed changes (left blank if not applicable).
> List by using - [ ] and the issue number, e.g. `- [ ] #1` or `- [x] #1` if the issue is closed/solved.

## Testing

> Help me how can I test or look at the changes (left blank if not applicable).

## Screenshots

> Include screenshots of the results or screenshots that help to see changes (left blank if not applicable).

## Notes

> Some additional notes if necessary (left blank if not applicable).
