### PR TITLE
fix: :bug: incorrect touch selection for `PokemonCard`

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -89,18 +89,17 @@ class _HomePageState extends State<HomePage> {
               itemCount: _pokemons.length + 1,
               itemBuilder: (context, index) {
                 if (index < _pokemons.length) {
-                  return InkWell(
-                    child: PokemonCard(pokemon: _pokemons[index]),
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        CreateAnimatedRoute(
-                          page: PokemonPage(
-                              partialPokemon: _pokemons[index].name),
-                        ).slideVertically(),
-                      );
-                    },
-                  );
+                  return PokemonCard(
+                      pokemon: _pokemons[index],
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          CreateAnimatedRoute(
+                            page: PokemonPage(
+                                partialPokemon: _pokemons[index].name),
+                          ).slideVertically(),
+                        );
+                      });
                 } else if (!isLimit) {
                   return const Card(
                     child: Padding(

--- a/lib/widgets/cards/pokemon.dart
+++ b/lib/widgets/cards/pokemon.dart
@@ -13,10 +13,12 @@ const Map<String, int> colorsShade = {
 };
 
 class PokemonCard extends StatelessWidget {
+  final void Function()? onTap;
   final Pokemon pokemon;
 
   const PokemonCard({
     super.key,
+    this.onTap,
     required this.pokemon,
   });
 
@@ -49,162 +51,169 @@ class PokemonCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       color: combineCardAndTypesColors(context),
-      child: Row(
-        children: [
-          Expanded(
-            flex: 4,
-            child: Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.all(5),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        flex: 1,
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: (combineTypesColors())[colorsShade['id']!],
-                            borderRadius: const BorderRadius.only(
-                              topLeft: Radius.circular(5),
-                              bottomLeft: Radius.circular(5),
+      clipBehavior: Clip.hardEdge,
+      child: InkWell(
+        onTap: onTap,
+        child: Row(
+          children: [
+            Expanded(
+              flex: 4,
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(5),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          flex: 1,
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: (combineTypesColors())[colorsShade['id']!],
+                              borderRadius: const BorderRadius.only(
+                                topLeft: Radius.circular(5),
+                                bottomLeft: Radius.circular(5),
+                              ),
                             ),
-                          ),
-                          child: Center(
-                            child: Text(
-                              pokemon.id.toString(),
-                              style: TextStyle(
-                                color: getTextColor(
-                                  (combineTypesColors())[colorsShade['id']!],
+                            child: Center(
+                              child: Text(
+                                pokemon.id.toString(),
+                                style: TextStyle(
+                                  color: getTextColor(
+                                    (combineTypesColors())[colorsShade['id']!],
+                                  ),
+                                  fontWeight: FontWeight.bold,
                                 ),
-                                fontWeight: FontWeight.bold,
                               ),
                             ),
                           ),
                         ),
-                      ),
-                      Expanded(
-                        flex: 3,
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: (combineTypesColors())[colorsShade['name']!],
-                            borderRadius: const BorderRadius.only(
-                              topRight: Radius.circular(5),
-                              bottomRight: Radius.circular(5),
-                            ),
-                          ),
-                          child: Center(
-                            child: Text(
-                              '${pokemon.name[0].toUpperCase()}${pokemon.name.substring(1)}',
-                              style: TextStyle(
-                                color: getTextColor(
+                        Expanded(
+                          flex: 3,
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color:
                                   (combineTypesColors())[colorsShade['name']!],
+                              borderRadius: const BorderRadius.only(
+                                topRight: Radius.circular(5),
+                                bottomRight: Radius.circular(5),
+                              ),
+                            ),
+                            child: Center(
+                              child: Text(
+                                '${pokemon.name[0].toUpperCase()}${pokemon.name.substring(1)}',
+                                style: TextStyle(
+                                  color: getTextColor(
+                                    (combineTypesColors())[
+                                        colorsShade['name']!],
+                                  ),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(5),
-                  child: Row(
-                    children: pokemon.types
-                        .map(
-                          (type) => Expanded(
-                            child: Padding(
-                              padding: EdgeInsets.only(
-                                  left: type == pokemon.types.first ? 0 : 2.5,
-                                  right: type == pokemon.types.last ? 0 : 2.5),
-                              child: Container(
-                                decoration: BoxDecoration(
-                                  color: (palette['types']
-                                      ?[type.type.name])?[colorsShade['type']!],
-                                  borderRadius: const BorderRadius.all(
-                                      Radius.circular(5)),
-                                ),
-                                child: Center(
-                                  child: Text(
-                                    type.type.name[0].toUpperCase() +
-                                        type.type.name.substring(1),
-                                    style: TextStyle(
-                                      color: getTextColor(
-                                        (palette['types']?[type.type.name])?[
-                                            colorsShade['type']!],
+                  Padding(
+                    padding: const EdgeInsets.all(5),
+                    child: Row(
+                      children: pokemon.types
+                          .map(
+                            (type) => Expanded(
+                              child: Padding(
+                                padding: EdgeInsets.only(
+                                    left: type == pokemon.types.first ? 0 : 2.5,
+                                    right:
+                                        type == pokemon.types.last ? 0 : 2.5),
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: (palette['types']?[type.type.name])?[
+                                        colorsShade['type']!],
+                                    borderRadius: const BorderRadius.all(
+                                        Radius.circular(5)),
+                                  ),
+                                  child: Center(
+                                    child: Text(
+                                      type.type.name[0].toUpperCase() +
+                                          type.type.name.substring(1),
+                                      style: TextStyle(
+                                        color: getTextColor(
+                                          (palette['types']?[type.type.name])?[
+                                              colorsShade['type']!],
+                                        ),
                                       ),
                                     ),
                                   ),
                                 ),
                               ),
                             ),
+                          )
+                          .toList(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              flex: 1,
+              child: Column(
+                children: [
+                  Container(
+                    constraints: BoxConstraints(
+                      maxHeight: MediaQuery.of(context).size.height <
+                              MediaQuery.of(context).size.width
+                          ? MediaQuery.of(context).size.height * 0.17
+                          : MediaQuery.of(context).size.width * 0.21,
+                    ),
+                    child: Stack(
+                      children: [
+                        LayoutBuilder(
+                          builder: (context, constraints) {
+                            double iconSize =
+                                constraints.maxHeight > constraints.maxWidth
+                                    ? constraints.maxWidth * 1
+                                    : constraints.maxHeight * 1;
+                            return Center(
+                              child: Icon(
+                                Icons.catching_pokemon,
+                                size: iconSize,
+                                color: (combineTypesColors())[
+                                    colorsShade['sprite']!],
+                              ),
+                            );
+                          },
+                        ),
+                        Center(
+                          child: CarouselSlider(
+                            options: CarouselOptions(
+                              aspectRatio: 1,
+                              viewportFraction: 1,
+                              enlargeCenterPage: true,
+                              enableInfiniteScroll: false,
+                              enlargeFactor: 2,
+                            ),
+                            items: [
+                              pokemon.sprites.frontDefault,
+                              pokemon.sprites.backDefault
+                            ]
+                                .whereType<String>()
+                                .map(
+                                  (sprite) => Image.network(
+                                    sprite,
+                                    fit: BoxFit.contain,
+                                  ),
+                                )
+                                .toList(),
                           ),
                         )
-                        .toList(),
+                      ],
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-          Expanded(
-            flex: 1,
-            child: Column(
-              children: [
-                Container(
-                  constraints: BoxConstraints(
-                    maxHeight: MediaQuery.of(context).size.height <
-                            MediaQuery.of(context).size.width
-                        ? MediaQuery.of(context).size.height * 0.17
-                        : MediaQuery.of(context).size.width * 0.21,
-                  ),
-                  child: Stack(
-                    children: [
-                      LayoutBuilder(
-                        builder: (context, constraints) {
-                          double iconSize =
-                              constraints.maxHeight > constraints.maxWidth
-                                  ? constraints.maxWidth * 1
-                                  : constraints.maxHeight * 1;
-                          return Center(
-                            child: Icon(
-                              Icons.catching_pokemon,
-                              size: iconSize,
-                              color: (combineTypesColors())[
-                                  colorsShade['sprite']!],
-                            ),
-                          );
-                        },
-                      ),
-                      Center(
-                        child: CarouselSlider(
-                          options: CarouselOptions(
-                            aspectRatio: 1,
-                            viewportFraction: 1,
-                            enlargeCenterPage: true,
-                            enableInfiniteScroll: false,
-                            enlargeFactor: 2,
-                          ),
-                          items: [
-                            pokemon.sprites.frontDefault,
-                            pokemon.sprites.backDefault
-                          ]
-                              .whereType<String>()
-                              .map(
-                                (sprite) => Image.network(
-                                  sprite,
-                                  fit: BoxFit.contain,
-                                ),
-                              )
-                              .toList(),
-                        ),
-                      )
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
# Description

> Describe the changes made by this pull request.

This PR fixes the incorrect painting/shadow when touching a `PokemonCard`.

modify:
- `PokemonCard` now has `Inkwell` widget implemented to avoid touch selection issues. It's only available when passing a function on the onTap prop

## Related issues

> List related issues (if any) and/or @mentions of the person or team responsible for reviewing proposed changes (left blank if not applicable).
> List by using - [ ] and the issue number, e.g. `- [ ] #1` or `- [x] #1` if the issue is closed/solved.

- [x] #31

## Testing

> Help me how can I test or look at the changes (left blank if not applicable).

## Screenshots

> Include screenshots of the results or screenshots that help to see changes (left blank if not applicable).

<table>
  <thead>
    <tr>
      <th colspan="2" style="text-align: center;">Theme</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th style="text-align: center;">Dark</th>
      <th style="text-align: center;">Light</th>
    </tr>
    <tr>
      <td><img src="https://github.com/BlessInSoftware/PocketDex/assets/45635827/817349ed-09c1-4c0e-822a-3f5701640e61" alt="Dark card"></td>
      <td><img src="https://github.com/BlessInSoftware/PocketDex/assets/45635827/e49e2d0c-35f2-492a-a639-2e926755d233" alt="Light card"></td>
    </tr>
  </tbody>
</table>

## Notes

> Some additional notes if necessary (left blank if not applicable).
